### PR TITLE
Refactor write_program(...) and only write_program if program not already written.

### DIFF
--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -1,6 +1,14 @@
 SRC_DIR = src
 BUILD_DIR = build
 
+# ft232h, is a common USB to serial converter that can be used as a programmer. 
+# You can this to match the programmer you're using. 
+#
+# Some other common programmers:
+#  - arduino
+#  - usbasp
+PROGRAMMER = usbasp # ft232h
+
 # The CC variable typically represents the C compiler that will be used during the
 # compilation process. By assigning avr-gcc to CC, it indicates that the avr-gcc
 # compiler is being used for compiling the C source files in the project.
@@ -94,17 +102,16 @@ disassemble: $(BUILD_DIR) hex_and_bin
 # configure fuse bits in order to enable BOOTRST and set size of bootloader section to 512 words = 1024 bytes.
 # bootloader start address (in words) = 0x3E00 => (in bytes) = 0x7C00 = 31744
 write_fusebits:
-	avrdude -c ft232h -p m328p -U lfuse:w:0xFF:m -U hfuse:w:0xDC:m -U efuse:w:0xFD:m 
+	avrdude -c $(PROGRAMMER) -p m328p -U lfuse:w:0xFF:m -U hfuse:w:0xDC:m -U efuse:w:0xFD:m 
 
 # upload the built program (hex file) to Atmega328P
 upload: hex_and_bin
-	avrdude -c ft232h -p m328p -U flash:w:$(BUILD_DIR)/program.hex
+	avrdude -c $(PROGRAMMER) -p m328p -U flash:w:$(BUILD_DIR)/program.hex
 # avrdude:
 # The command-line tool used for programming AVR microcontrollers.
 
-# -c ft232h:
-# Specifies the programmer type. In this case, it indicates that an FT232H board
-# is being used as the programmer. The specific programmer type may vary depending
+# -c $(PROGAMMER):
+# Specifies the programmer type. The specific programmer type may vary depending
 # on the hardware setup.
 
 # -p m328p:

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -55,6 +55,10 @@ else
 	ifeq ($(shell uname | cut -d _ -f 1), MINGW64)
 		MK_DIR = mkdir -pv
 	endif
+
+	ifeq ($(shell uname), Darwin)
+		MK_DIR = mkdir -pv
+	endif
 endif
 
 all: hex_and_bin

--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -45,7 +45,7 @@ void write_program(const uint32_t address, uint8_t *program_buffer, const uint32
     
     // iterate through the program_buffer one page at a time
     for (uint32_t current_page_address = address; 
-         current_page_address <= (address + program_buffer_size); 
+         current_page_address < (address + program_buffer_size); 
          current_page_address += SPM_PAGESIZE) 
     {
         boot_page_erase(current_page_address);


### PR DESCRIPTION
This PR hopes to accomplish a few things:
 * Refactors the write_program(..) method 
   * I think passing `buffer_size` as an argument is cleaner than having #defines
   * I think just iterating page by page, byte by byte is less fussy than differentiating between "last page" vs "other page".
   * Explicitly write 0xffff words to the "temporary page buffer" to fill the remainder of the final page. I'm not sure if this is necessary (perhaps its starts 0xff'd and `boot_page_write` also 0xff's it), but from what I can tell it is a best practice.
   
 * Only write the program if no program is already there. I like this better because it won't write to flash on every power cycle -- and if the Uno is resetting repeatedly for some reason, it won't keep writing to flash (which has a limited ~10,000 writes per page).
 
 * Add MacOs support in the Makefile
