### PR TITLE
Fix listening for a Start-Of-Frame byte

### DIFF
--- a/first-steps/3-simple-uart-protocol/mcu/sup.c
+++ b/first-steps/3-simple-uart-protocol/mcu/sup.c
@@ -119,19 +119,15 @@ void sup_handle_rx_byte(const uint8_t byte)
         return;
     }
 
-    // Always listen for a Start-Of-Frame byte, which can reset a broken frame transmission.
-    if (byte == SUP_SOF)
-    {
-        reset_rx_frame_state();
-        rx_frame_state->parsing_state = SUP_STATE_WAIT_ID;
-        return;
-    }
-
     switch (rx_frame_state->parsing_state)
     {
         case SUP_STATE_WAIT_SOF:
-            // This state is effectively handled by the check above,
-            // but we keep the case for clarity. Any byte other than SOF is ignored.
+            // Listen for a Start-Of-Frame byte. Any byte other than SOF is ignored.
+            if (byte == SUP_SOF)
+            {
+                reset_rx_frame_state();
+                rx_frame_state->parsing_state = SUP_STATE_WAIT_ID;
+            }
             break;
 
         case SUP_STATE_WAIT_ID:


### PR DESCRIPTION
### Summary

**Fixes:** Application update failure when binary contains Start-Of-Frame byte (0xA1)

### Problem Description

The SUP frame parser (device side only) incorrectly resets the data reception state machine upon encountering any 0xA1 byte, even when it was part of the actual application data rather than an actual frame boundary.

### Solution

Wait for SOF byte when parser is in the `SUP_STATE_WAIT_SOF` state only.

### Notes

This fix addresses the immediate issue but removes the ability to reset broken frame transmissions using SOF bytes. In my opinion, frame reset/recovery should be handled through alternative mechanisms.